### PR TITLE
Fix pandas dtype error in PhaTYP: assign float 0.0 instead of string '0'

### DIFF
--- a/src/phabox2/phatyp.py
+++ b/src/phabox2/phatyp.py
@@ -217,7 +217,7 @@ def run(inputs):
         rows_to_update = ~merged_df['Lineage'].apply(lambda lineage: any(group in lineage for group in ProkaryoticGroup))
         # Update the pred_csv dataframe
         pred_csv.loc[rows_to_update, 'TYPE'] = '-'
-        pred_csv.loc[rows_to_update, 'PhaTYPScore'] = '0'
+        pred_csv.loc[rows_to_update, 'PhaTYPScore'] = 0.0
 
     pred_csv.to_csv(f'{rootpth}/{out_dir}/phatyp_prediction.tsv', index = False, sep='\t')
 


### PR DESCRIPTION
Problem: phabox2 crashes during PhaTYP lifestyle prediction with TypeError: Invalid value '0' for dtype 'float64'. This occurs in phatyp.py line 220 where a string '0' is assigned to a float64 column. pandas 2.0+ enforces strict dtype coercion and raises an error instead of silently casting. Fix: change pred_csv.loc[rows_to_update, 'PhaTYPScore'] = '0' to pred_csv.loc[rows_to_update, 'PhaTYPScore'] = 0.0. Tested on phabox2 2.2, pandas 3.0.2, Python 3.12.